### PR TITLE
Added ' (single quote) to symbols list

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ var resDemo = doc.querySelector( "#demo" );
 
 var expanders = doc.querySelectorAll( ".expander" );
 var expandedClass = "expanded";
-var symbols = /[\r\n"%#()<>?\[\\\]^`{|}]/g;
+var symbols = /[\r\n"%#()<>?\[\\\]^`'{|}]/g;
 
 // Textarea Actions
 //----------------------------------------


### PR DESCRIPTION
Currently if we didn't escape single quote in Firefox it starts to gives errors. By adding single quote to the symbol list should fix this.