### PR TITLE
encode -> encodeURIComponent

### DIFF
--- a/script.js
+++ b/script.js
@@ -143,7 +143,7 @@ function encodeSVG( data ) {
     data = data.replace( />\s{1,}</g, "><" );
     data = data.replace( /\s{2,}/g, " " );
 
-    return data.replace( symbols, escape );
+    return data.replace( symbols, encodeURIComponent );
 }
 
 


### PR DESCRIPTION
encode is deprecated: https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/escape

encodeURIComponent works better than encodeURI for SVG in FF